### PR TITLE
add mod= option to remove module prefixes from type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ Number
          \-- Unsigned
 ```
 
+Type names can be displayed without module prefixes by using the `mod=` option.
+
+```julia
+julia> print(tt(Base.LibuvStream)...)
+Base.LibuvStream
+ ├─ Base.BufferStream
+ ├─ Base.PipeEndpoint
+ ├─ Base.TTY
+ ├─ Sockets.TCPSocket
+ └─ Sockets.UDPSocket
+
+julia> print(tt(Base.LibuvStream; mod=Base)...)
+LibuvStream
+ ├─ BufferStream
+ ├─ PipeEndpoint
+ ├─ TTY
+ ├─ Sockets.TCPSocket
+ └─ Sockets.UDPSocket
+```
+
 # About
 
 ## Author

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -5,7 +5,7 @@
 using InteractiveUtils: subtypes
 
 """
-`function tt(TY::Type, pref=("",); uni=true, concrete=true)`\n
+`function tt(TY::Type, pref=("",); uni=true, concrete=true, mod=nothing)`\n
 Returns a `Vector{String}` of type entries formatted as a tree for human (programmer)
 inspection.
 
@@ -13,20 +13,33 @@ inspection.
 - The `pref` optional argument is a text prefix;
 - The `uni` optional keyword argument controls whether Unicode characters will be used;
 - The `concrete` optional keyword argument controls whether to filter off concrete subtypes.
+- The `mod` optional keyword argument removes module prefixes from type names.
 """
-function tt(TY::Type, pref=("",); uni=true, concrete=true)
+function tt(TY::Type, pref=("",); uni=true, concrete=true, mod=nothing)
     ret = Array{String,1}()
     ELL, FRK, BAR = uni ? (" └─ ", " ├─ ", " │  ") : (" \\-- ", " +-- ", " |  ")
     SPC = "    "
     LEN = length(pref) - 1
     PREF = LEN > 0 ? ( i == ELL ? SPC : i == FRK ? BAR : i for i in pref[1:LEN]) : ("",)
-    append!(ret, ["$(join((PREF..., pref[end])))$(TY)\n"])
+    append!(ret, ["$(join((PREF..., pref[end])))$(typename(TY, mod))\n"])
     ST = [i for i in subtypes(TY) if isabstracttype(i) || concrete]
     LE = length(ST)
     for i in 1:LE
         append!(
-            ret, tt(ST[i], (pref..., i < LE ? FRK : ELL), uni=uni, concrete=concrete)
+            ret, tt(ST[i], (pref..., i < LE ? FRK : ELL); uni, concrete, mod)
         )
     end
     ret
+end
+
+"""
+    typename(SomeModule.SomeType) -> "SomeModule.SomeType"
+    typename(SomeModule.SomeType, SomeModule) -> "SomeType"
+
+Returns the name of SomeType in the context of SomeModule.
+"""
+function typename(TY::Type, mod)
+    io = IOBuffer()
+    show(mod == nothing ? io : IOContext(io, :module => mod), TY)
+    String(take!(io))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,9 +10,13 @@ using Test
 #                                          Test Data                                           #
 #==============================================================================================#
 
+module M
+
 #----------------------------------------------------------------------------------------------#
 #                                        Abstract types                                        #
 #----------------------------------------------------------------------------------------------#
+
+export Ab
 
 abstract type tyTree <: Any end
 abstract type A <: tyTree end
@@ -26,29 +30,51 @@ abstract type Ba <: B end
 #                                        Concrete types                                        #
 #----------------------------------------------------------------------------------------------#
 
+export Aα
+
 struct Aα <: A end
 struct Aaα <: Aa end
 struct Aaβ <: Aa end
 struct Abα <: Ab end
+
+end # module M
 
 
 #==============================================================================================#
 #                                            Tests                                             #
 #==============================================================================================#
 
+using Main.M
+
 @testset "quiz.type.abstract:                                                     " begin
     # All types
-    @test length(tt(A)) == 7
-    @test length(tt(Aa)) == 3
+    @test length(tt(M.A)) == 7
+    @test length(tt(M.Aa)) == 3
     @test length(tt(Ab)) == 2
-    @test length(tt(B)) == 2
-    @test length(tt(Ba)) == 1
-    @test length(tt(tyTree)) == 10
+    @test length(tt(M.B)) == 2
+    @test length(tt(M.Ba)) == 1
+    @test length(tt(M.tyTree)) == 10
     # Abstract types only
-    @test length(tt(A, concrete=false)) == 3
-    @test length(tt(Aa, concrete=false)) == 1
+    @test length(tt(M.A, concrete=false)) == 3
+    @test length(tt(M.Aa, concrete=false)) == 1
     @test length(tt(Ab, concrete=false)) == 1
-    @test length(tt(B, concrete=false)) == 2
-    @test length(tt(Ba, concrete=false)) == 1
-    @test length(tt(tyTree, concrete=false)) == 6
+    @test length(tt(M.B, concrete=false)) == 2
+    @test length(tt(M.Ba, concrete=false)) == 1
+    @test length(tt(M.tyTree, concrete=false)) == 6
+
+    @test contains(join(tt(M.tyTree)), " Main.M.Aa\n")
+    @test contains(join(tt(M.tyTree)), " Ab\n")
+    @test contains(join(tt(M.tyTree)), " Aα\n")
+
+    @test !contains(join(tt(M.tyTree)), " Aa\n")
+    @test !contains(join(tt(M.tyTree)), " Main.M.Ab\n")
+    @test !contains(join(tt(M.tyTree)), " Main.M.Aα\n")
+
+    @test contains(join(tt(M.tyTree; mod=Main.M)), " Aa\n")
+    @test contains(join(tt(M.tyTree; mod=Main.M)), " Ab\n")
+    @test contains(join(tt(M.tyTree; mod=Main.M)), " Aα\n")
+
+    @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Aa\n")
+    @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Ab\n")
+    @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Aα\n")
 end


### PR DESCRIPTION
I have a docstring that uses `tt` like this:

    """
        open(...)

    blah ...

    `open` returns `UnixIO{FDType}`, where `FDType` is one of:

    ```
    $(join(typetree(FDType)))
    ```
    """
It renders like this (a bit too verbose):

```
  UnixIO.FDType
   ├─ UnixIO.File
   │   ├─ UnixIO.S_IFBLK
   │   └─ UnixIO.S_IFREG
   ...
```

With this PR I can do: `typetree(FDType; mod=UnixIO)`, and now it renders like this:

```
  FDType
   ├─ File
   │   ├─ S_IFBLK
   │   └─ S_IFREG
   ├─ MetaFile
   │   ├─ S_IFDIR
   │   └─ S_IFLNK
   ├─ PidFD
   └─ Stream
       ├─ S_IFCHR
       │   ├─ CanonicalMode
       │   └─ Pseudoterminal
       ├─ S_IFIFO
       └─ S_IFSOCK
```