### PR TITLE
Fix infinite recursion

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -22,7 +22,7 @@ function tt(TY::Type, pref=("",); uni=true, concrete=true, mod=nothing)
     LEN = length(pref) - 1
     PREF = LEN > 0 ? ( i == ELL ? SPC : i == FRK ? BAR : i for i in pref[1:LEN]) : ("",)
     append!(ret, ["$(join((PREF..., pref[end])))$(typename(TY, mod))\n"])
-    ST = [i for i in subtypes(TY) if isabstracttype(i) || concrete]
+    ST = [i for i in subtypes(TY) if (isabstracttype(i) || concrete) && i !== Any]
     LE = length(ST)
     for i in 1:LE
         append!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,4 +77,7 @@ using Main.M
     @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Aa\n")
     @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Ab\n")
     @test !contains(join(tt(M.tyTree; mod=Main.M)), " Main.M.Aα\n")
+
+    # Any type: check for lack of infinite recursion
+    @test length(tt(Any)) >= 0
 end


### PR DESCRIPTION
Calling `tt(Any)` results in an infinite recursion, because `(Any in subtypes(Any)) == true`.

Fixes #2